### PR TITLE
Do no text-transform on admonition title

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -29,7 +29,6 @@ summary.admonition-title::after {
   font-weight: bold;
   display: block;
   margin-bottom: 10px;
-  text-transform: uppercase;
 }
 
 /* Unknown MkDocs displayed as info, unknown Docusaurus are not matched */


### PR DESCRIPTION
Markdown Admonitions could render admonition syntax for Materials for MkDocs, which support admonition title in addition to admonition type:

  https://squidfunk.github.io/mkdocs-material/reference/admonitions/#changing-the-title

However, the default CSS will make the title all uppercase. This if fine if the admonition only have the "type" in title. But will make the customized title less readable.

Therefore, remove `text-transform` CSS style to avoid force uppercase.